### PR TITLE
fix(bug): whitespace bug and can save more than one word.

### DIFF
--- a/karma.py
+++ b/karma.py
@@ -45,15 +45,30 @@ async def handle_karma_command(message):
 def update_karma(message):
     # Parse message for karma updates
     words = message.content.split()
-    for word in words:
-        if word.endswith('++'):
-            entry = word[:-2]  # Remove '++'
-            karma_data[entry] = karma_data.get(entry, 0) + 1
-            save_karma_data()
-        elif word.endswith('--'):
-            entry = word[:-2]  # Remove '--'
-            karma_data[entry] = karma_data.get(entry, 0) - 1
-            save_karma_data()
+
+    # Parse message for karma updates
+    words = message.content.split()[1:]
+    # define action to store the add or substraction
+    action = ""
+    # variable that holds the desired tech, person or thing to value
+    entry = ""
+
+    # if the content of the message contains an space, or the same
+    # that is has more than one word
+    if len(words) >= 2:
+        action = words[-1][-2:]
+        # join all words except the last one
+        entry = f"{' '.join(words[:-1])} {words[-1][:-2]}"
+    else:
+        entry = words[0][:-2]
+        action = words[0][-2:]
+
+    if action =='++':
+        karma_data[entry] = karma_data.get(entry, 0) + 1
+        save_karma_data()
+    elif action == '--':
+        karma_data[entry] = karma_data.get(entry, 0) - 1
+        save_karma_data()
 
 def save_karma_data():
     # Save karma data to the file


### PR DESCRIPTION
- [x] #1 

The proposed solution is to take all words after the command and only remove the action from the last part.
![image](https://github.com/alexiarstein/karma/assets/50756389/bd498eaf-1352-473a-bf05-2472d59f470f)

- [ ] Tested: no, I'm not sure how to fully setup the bot to proper testing, but I've tested like the image above using the following code:

```py
def update_karma(message):
    # Parse message for karma updates
    words = message.content.split()[1:]
    # define action to store the add or substraction
    action = ""
    # variable that holds the desired tech, person or thing to value
    entry = ""

    # if the content of the message contains an space, or the same
    # that is has more than one word
    if len(words) >= 2:
        print("has more than two words or equal")
        action = words[-1][-2:]
        # join all words except the last one
        entry = f"{' '.join(words[:-1])} {words[-1][:-2]}"
    else:
        print("has only one word")
        entry = words[0][:-2]
        action = words[0][-2:]

    print(f"Action: {action} Entry: {entry}")


# Test the function with a valid object
class Message:
		def __init__(self, content):
				self.content = content

message = Message('!karma Linus Torvalds++')
print("Test 1")
print(f"Message: {message.content}")
update_karma(message)
message2 = Message('!karma Redhat++')
print("Test 2")
print(f"Message: {message2.content}")
update_karma(message2)
```